### PR TITLE
Promote KKR in sponsors and clear upcoming events

### DIFF
--- a/app/data/events.ts
+++ b/app/data/events.ts
@@ -8,76 +8,7 @@ export interface Event {
   link: string;
 }
 
-export const events: Event[] = [
-  {
-    id: "warburg-pitch-comp",
-    title: "Warburg Pitch Competition",
-    date: "March 21, 2026",
-    time: "10am–1pm",
-    type: "Case Competition",
-    link: "#",
-  },
-  {
-    id: "american-securities-info-session",
-    title: "American Securities Info Session",
-    date: "March 25, 2026",
-    time: "5:30–6:30pm",
-    type: "Info Session",
-    link: "#",
-  },
-  {
-    id: "blair-effron-fireside-chat",
-    title: "Fireside Chat with Blair Effron: Founder of Centerview Partners",
-    date: "March 26, 2026",
-    time: "5:30–6:30pm",
-    location: "JMHH G03",
-    type: "Speaker Event",
-    link: "https://groups.wharton.upenn.edu/pevc/rsvp_boot?id=123647",
-  },
-  {
-    id: "ta-associates-networking-dinner",
-    title: "TA Associates Networking Session & Dinner",
-    date: "March 31, 2026",
-    time: "6–7:30pm",
-    location: "The Inn at Penn",
-    type: "Networking",
-    link: "#",
-  },
-  {
-    id: "american-securities-networking-session",
-    title: "American Securities Networking Session",
-    date: "April 7, 2026",
-    time: "6–7pm",
-    location: "JMHH 345",
-    type: "Networking",
-    link: "#",
-  },
-  {
-    id: "atlas-partners-info-session",
-    title: "Atlas Partners Info Session",
-    date: "April 15, 2026",
-    time: "6–7pm",
-    location: "JMHH 245",
-    type: "Info Session",
-    link: "#",
-  },
-  {
-    id: "silver-lake-info-session",
-    title: "Silver Lake Info Session",
-    date: "April 16, 2026",
-    time: "7–8pm",
-    type: "Info Session",
-    link: "#",
-  },
-  {
-    id: "silver-lake-competition",
-    title: "Silver Lake Competition",
-    date: "April 17, 2026",
-    time: "10–11am",
-    type: "Case Competition",
-    link: "#",
-  },
-];
+export const events: Event[] = [];
 
 export const getTypeColor = (type: Event["type"]) => {
   switch (type) {

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { events, getTypeColor } from "../data/events";
 import PastEventsCarousel from "../components/PastEventsCarousel";
 import HighlightedEvents from "../components/HighlightedEvents";
@@ -21,51 +20,52 @@ export default function Events() {
       {/* Navigation */}
       <Navbar activeLink="/events" />
 
-      {/* Upcoming Events Section */}
-      <section className="bg-white py-12 md:py-16 lg:py-20">
-        <div className="px-6 md:px-12 lg:px-20 xl:px-32">
-          {/* Section Header */}
-          <div className="flex items-center gap-6 mb-8 md:mb-16 animate-page-intro">
-            <div className="w-16 border-t-2 border-dashed border-gray-400 shrink-0" />
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-light text-gray-900">
-              Upcoming Events
-            </h1>
-          </div>
+      {upcomingEvents.length > 0 && (
+        <section className="bg-white py-12 md:py-16 lg:py-20">
+          <div className="px-6 md:px-12 lg:px-20 xl:px-32">
+            {/* Section Header */}
+            <div className="flex items-center gap-6 mb-8 md:mb-16 animate-page-intro">
+              <div className="w-16 border-t-2 border-dashed border-gray-400 shrink-0" />
+              <h1 className="text-2xl md:text-3xl lg:text-4xl font-light text-gray-900">
+                Upcoming Events
+              </h1>
+            </div>
 
-          {/* Events Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 animate-page-intro">
-            {upcomingEvents.map((event) => (
-              <a
-                key={event.id}
-                href={event.link}
-                target={event.link.startsWith("http") ? "_blank" : undefined}
-                rel={event.link.startsWith("http") ? "noopener noreferrer" : undefined}
-                className="group block"
-              >
-                <div className="flex items-center gap-3 mb-3">
-                  <span className={`text-xs font-medium px-3 py-1 rounded ${getTypeColor(event.type)}`}>
-                    {event.type}
-                  </span>
-                  <span className="text-sm text-gray-500">{event.date}</span>
-                </div>
-                <h3 className="text-xl font-medium text-gray-900 group-hover:text-blue-900 transition-colors">
-                  {event.title}
-                </h3>
-                {(event.time || event.location) && (
-                  <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
-                    {event.time && (
-                      <span className="text-sm text-gray-500">{event.time}</span>
-                    )}
-                    {event.location && (
-                      <span className="text-sm text-gray-500">{event.location}</span>
-                    )}
+            {/* Events Grid */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 animate-page-intro">
+              {upcomingEvents.map((event) => (
+                <a
+                  key={event.id}
+                  href={event.link}
+                  target={event.link.startsWith("http") ? "_blank" : undefined}
+                  rel={event.link.startsWith("http") ? "noopener noreferrer" : undefined}
+                  className="group block"
+                >
+                  <div className="flex items-center gap-3 mb-3">
+                    <span className={`text-xs font-medium px-3 py-1 rounded ${getTypeColor(event.type)}`}>
+                      {event.type}
+                    </span>
+                    <span className="text-sm text-gray-500">{event.date}</span>
                   </div>
-                )}
-              </a>
-            ))}
+                  <h3 className="text-xl font-medium text-gray-900 group-hover:text-blue-900 transition-colors">
+                    {event.title}
+                  </h3>
+                  {(event.time || event.location) && (
+                    <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+                      {event.time && (
+                        <span className="text-sm text-gray-500">{event.time}</span>
+                      )}
+                      {event.location && (
+                        <span className="text-sm text-gray-500">{event.location}</span>
+                      )}
+                    </div>
+                  )}
+                </a>
+              ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       {/* Highlighted Events Section */}
       <section className="bg-[#fafafa] py-12 md:py-16 lg:py-20">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,52 +66,53 @@ export default function Home() {
       {/* What We Do — sticky scroll narrative with parallax images */}
       <WhatWeDoSection />
 
-      {/* Events Section — staggered card reveals */}
-      <section className="bg-white pt-20 md:pt-28 lg:pt-36 pb-24 md:pb-32 lg:pb-40">
-        <div className="px-6 md:px-12 lg:px-20 xl:px-32">
-          {/* Section Header */}
-          <ScrollReveal variant="fade-up">
-            <div className="flex items-center justify-between mb-8 md:mb-16">
-              <div className="flex items-center gap-6">
-                <div className="w-16 border-t-2 border-dashed border-gray-400 shrink-0" />
-                <h2 className="text-2xl md:text-3xl lg:text-4xl font-light text-gray-900">
-                  Upcoming Events
-                </h2>
-              </div>
-              <Link
-                href="/events"
-                className="text-gray-900 text-sm font-medium border-b border-gray-900 pb-1 hover:opacity-70 transition-opacity"
-              >
-                View All
-              </Link>
-            </div>
-          </ScrollReveal>
-
-          {/* Events Grid — staggered card reveals */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {events.slice(0, 3).map((event, i) => (
-              <ScrollReveal key={event.id} variant="fade-up" delay={i * 0.12}>
-                <a
-                  href={event.link}
-                  target={event.link.startsWith("http") ? "_blank" : undefined}
-                  rel={event.link.startsWith("http") ? "noopener noreferrer" : undefined}
-                  className="group block"
+      {events.length > 0 && (
+        <section className="bg-white pt-20 md:pt-28 lg:pt-36 pb-24 md:pb-32 lg:pb-40">
+          <div className="px-6 md:px-12 lg:px-20 xl:px-32">
+            {/* Section Header */}
+            <ScrollReveal variant="fade-up">
+              <div className="flex items-center justify-between mb-8 md:mb-16">
+                <div className="flex items-center gap-6">
+                  <div className="w-16 border-t-2 border-dashed border-gray-400 shrink-0" />
+                  <h2 className="text-2xl md:text-3xl lg:text-4xl font-light text-gray-900">
+                    Upcoming Events
+                  </h2>
+                </div>
+                <Link
+                  href="/events"
+                  className="text-gray-900 text-sm font-medium border-b border-gray-900 pb-1 hover:opacity-70 transition-opacity"
                 >
-                  <div className="flex items-center gap-3 mb-3">
-                    <span className={`text-xs font-medium px-3 py-1 rounded ${getTypeColor(event.type)}`}>
-                      {event.type}
-                    </span>
-                    <span className="text-sm text-gray-500">{event.date}</span>
-                  </div>
-                  <h3 className="text-xl font-medium text-gray-900 group-hover:text-blue-900 transition-colors">
-                    {event.title}
-                  </h3>
-                </a>
-              </ScrollReveal>
-            ))}
+                  View All
+                </Link>
+              </div>
+            </ScrollReveal>
+
+            {/* Events Grid — staggered card reveals */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+              {events.slice(0, 3).map((event, i) => (
+                <ScrollReveal key={event.id} variant="fade-up" delay={i * 0.12}>
+                  <a
+                    href={event.link}
+                    target={event.link.startsWith("http") ? "_blank" : undefined}
+                    rel={event.link.startsWith("http") ? "noopener noreferrer" : undefined}
+                    className="group block"
+                  >
+                    <div className="flex items-center gap-3 mb-3">
+                      <span className={`text-xs font-medium px-3 py-1 rounded ${getTypeColor(event.type)}`}>
+                        {event.type}
+                      </span>
+                      <span className="text-sm text-gray-500">{event.date}</span>
+                    </div>
+                    <h3 className="text-xl font-medium text-gray-900 group-hover:text-blue-900 transition-colors">
+                      {event.title}
+                    </h3>
+                  </a>
+                </ScrollReveal>
+              ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       {/* Footer */}
       <ScrollReveal variant="fade-in">

--- a/app/sponsors/page.tsx
+++ b/app/sponsors/page.tsx
@@ -42,6 +42,13 @@ const caseCompetitionPartners: Sponsor[] = [
 
 const platinumSponsors: Sponsor[] = [
   {
+    name: "KKR",
+    logo: "/sponsors/kkr.png",
+    description: "Global investment company managing $504 billion across private equity, real estate, credit, and hedge funds with 23 funds and 690+ investments worldwide.",
+    sector: "Private Equity",
+    website: "https://www.kkr.com",
+  },
+  {
     name: "American Securities",
     logo: "/sponsors/american-securities.png",
     description: "Leading private equity firm investing in market-leading North American companies with annual revenues generally ranging from $200 million to $2 billion.",
@@ -54,13 +61,6 @@ const platinumSponsors: Sponsor[] = [
     description: "Leading private company intelligence platform that helps dealmakers discover, research, and engage with private companies for sourcing and market mapping.",
     sector: "Technology",
     website: "https://www.grata.com",
-  },
-  {
-    name: "KKR",
-    logo: "/sponsors/kkr.png",
-    description: "Global investment company managing $504 billion across private equity, real estate, credit, and hedge funds with 23 funds and 690+ investments worldwide.",
-    sector: "Private Equity",
-    website: "https://www.kkr.com",
   },
   {
     name: "OceanSound Partners",


### PR DESCRIPTION
Move KKR to the top of the Sponsors list to highlight the partnership
alongside its Case Competition Partner role. Empty the events array and
conditionally render the Upcoming Events sections so the homepage and
events page hide them when no events are scheduled.